### PR TITLE
Bump Jinja2 from 3.1.5 to 3.1.6 in backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1


### PR DESCRIPTION
## Summary

- Bumps `Jinja2` from `3.1.5` to `3.1.6` in `backend/requirements.txt`

Fixes [GHSA-cpwx-vrp4-4pq7](https://github.com/advisories/GHSA-cpwx-vrp4-4pq7): Jinja2's `attr` filter could be used to select the `format` method on a string, allowing sandbox breakout. Fixed in 3.1.6.

## Test plan

- [ ] Backend starts without errors
- [ ] Dependabot alert #194 clears after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)